### PR TITLE
Send scope with 'Microsoft flow'

### DIFF
--- a/rpm/0005-Support-Microsoft-OAuth2-flow.patch
+++ b/rpm/0005-Support-Microsoft-OAuth2-flow.patch
@@ -1,19 +1,19 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Chris Adams <chris.adams@jollamobile.com>
 Date: Thu, 2 Apr 2020 14:30:48 +1000
-Subject: [PATCH] Support OneDrive oauth2 flow
+Subject: [PATCH] Support Microsoft OAuth2 flow
 
-OneDrive supports a slightly non-standard USER_AGENT flow where
+Microsoft accounts may use a slightly non-standard USER_AGENT flow where
 a bearer code may be exchanged for a token.
 
 Also, support using a dynamically determined redirect uri for
 the authorization code request.
 ---
- src/oauth2plugin.cpp | 98 ++++++++++++++++++++++++++------------------
- 1 file changed, 58 insertions(+), 40 deletions(-)
+ src/oauth2plugin.cpp | 101 ++++++++++++++++++++++++++-----------------
+ 1 file changed, 61 insertions(+), 40 deletions(-)
 
 diff --git a/src/oauth2plugin.cpp b/src/oauth2plugin.cpp
-index 3eb3fef..dc1dd7e 100644
+index 3eb3fef7a7bf2de0b2943d61300267f44907cc03..af3ca32b135ae00e4683d14b26a013a8c6011807 100644
 --- a/src/oauth2plugin.cpp
 +++ b/src/oauth2plugin.cpp
 @@ -395,7 +395,11 @@ void OAuth2Plugin::userActionFinished(const SignOn::UiSessionData &data)
@@ -29,7 +29,7 @@ index 3eb3fef..dc1dd7e 100644
  
      // Checking if authorization server granted access
      QUrl url = QUrl(data.UrlResponse());
-@@ -406,50 +410,63 @@ void OAuth2Plugin::userActionFinished(const SignOn::UiSessionData &data)
+@@ -406,50 +410,66 @@ void OAuth2Plugin::userActionFinished(const SignOn::UiSessionData &data)
      }
  
      if (d->m_mechanism == USER_AGENT) {
@@ -54,14 +54,17 @@ index 3eb3fef..dc1dd7e 100644
 -                    state = pair.second;
 -                } else if (pair.first == SCOPE) {
 -                    respData.setScope(pair.second.split(' ', QString::SkipEmptyParts));
-+        // some providers (e.g. OneDrive) implement non-standard OAuth2 flows
-+        // and return auth code requiring exchange for token.
++        // Some providers (e.g. OneDrive and Outlook) implement non-standard
++        // OAuth2 flows and return auth code requiring exchange for token.
 +        if (url.hasQueryItem(AUTH_CODE)) {
 +            QString code = url.queryItemValue(AUTH_CODE);
++            QStringList scopes = d->m_oauth2Data.Scope();
 +            QUrl newUrl;
 +            newUrl.addQueryItem(GRANT_TYPE, AUTHORIZATION_CODE);
 +            newUrl.addQueryItem(AUTH_CODE, code);
 +            newUrl.addQueryItem(REDIRECT_URI, redirectUri);
++            if (!scopes.isEmpty())
++                newUrl.addQueryItem(SCOPE, QUrl::toPercentEncoding(scopes.join(" ")));
 +            TRACE() << "USER_AGENT flow got auth code query item, sending auth code request:" << newUrl.toString();
 +            sendOAuth2PostRequest(newUrl,
 +                                  GrantType::AuthorizationCode);
@@ -131,7 +134,7 @@ index 3eb3fef..dc1dd7e 100644
      } else if (d->m_mechanism == WEB_SERVER || d->m_mechanism == OAUTH2) {
          // Access grant can be one of the floolwing types
          // 1. Authorization code (code, redirect_uri)
-@@ -472,7 +489,8 @@ void OAuth2Plugin::userActionFinished(const SignOn::UiSessionData &data)
+@@ -472,7 +492,8 @@ void OAuth2Plugin::userActionFinished(const SignOn::UiSessionData &data)
              QString code = url.queryItemValue(AUTH_CODE);
              newUrl.addQueryItem(GRANT_TYPE, AUTHORIZATION_CODE);
              newUrl.addQueryItem(AUTH_CODE, code);
@@ -141,6 +144,3 @@ index 3eb3fef..dc1dd7e 100644
              sendOAuth2PostRequest(newUrl,
                                    GrantType::AuthorizationCode);
          }
--- 
-2.37.2
-

--- a/rpm/signon-plugin-oauth2-qt5.spec
+++ b/rpm/signon-plugin-oauth2-qt5.spec
@@ -9,7 +9,7 @@ Patch0: 0001-Manually-time-out-HTTP-requests-after-30-seconds.patch
 Patch1: 0002-OAuth2-Relax-RefreshToken-restriction-on-ProvidedTok.patch
 Patch2: 0003-Always-install-to-usr-lib-never-usr-lib64.patch
 Patch3: 0004-Always-force-client-auth-via-request-body.patch
-Patch4: 0005-Support-OneDrive-oauth2-flow.patch
+Patch4: 0005-Support-Microsoft-oauth2-flow.patch
 Requires(post): /sbin/ldconfig
 Requires(postun): /sbin/ldconfig
 BuildRequires: pkgconfig(Qt5Network)


### PR DESCRIPTION
It seems this flow is not specific to just OneDrive but also used by Outlook.com accounts for other purposes. It also requires scope value.