### PR TITLE
signon-plugin-oauth2: Don't send code_challenge when token is requested

### DIFF
--- a/rpm/0001-Manually-time-out-HTTP-requests-after-30-seconds.patch
+++ b/rpm/0001-Manually-time-out-HTTP-requests-after-30-seconds.patch
@@ -12,7 +12,7 @@ manually after 30 seconds.
  2 files changed, 19 insertions(+)
 
 diff --git a/src/base-plugin.cpp b/src/base-plugin.cpp
-index aa2d639..60a7958 100644
+index aa2d639e78f14a87e266a4d58d272a203ba1ed6a..60a7958e207d619421e54c5ccef2c226c700df4d 100644
 --- a/src/base-plugin.cpp
 +++ b/src/base-plugin.cpp
 @@ -32,6 +32,7 @@
@@ -83,7 +83,7 @@ index aa2d639..60a7958 100644
  {
      Q_D(BasePlugin);
 diff --git a/src/base-plugin.h b/src/base-plugin.h
-index 9a72718..d5de1a8 100644
+index 9a727184f14e18d0aa1f51ff7d09561bb43763fe..d5de1a81b6dfd4be1b1da2cf56bd2663964c64e9 100644
 --- a/src/base-plugin.h
 +++ b/src/base-plugin.h
 @@ -74,6 +74,7 @@ protected:
@@ -94,6 +94,3 @@ index 9a72718..d5de1a8 100644
      void onNetworkError(QNetworkReply::NetworkError err);
      virtual void handleSslErrors(QList<QSslError> errorList);
  
--- 
-2.37.2
-

--- a/rpm/0002-OAuth2-Relax-RefreshToken-restriction-on-ProvidedTok.patch
+++ b/rpm/0002-OAuth2-Relax-RefreshToken-restriction-on-ProvidedTok.patch
@@ -12,7 +12,7 @@ is present in the token map.
  1 file changed, 2 insertions(+), 3 deletions(-)
 
 diff --git a/src/oauth2plugin.cpp b/src/oauth2plugin.cpp
-index 57df6d8..be39263 100644
+index 57df6d8819d5a14e8eb2090728f9dc023cd7f743..be39263083894ae7e190514f92c4996421eebba2 100644
 --- a/src/oauth2plugin.cpp
 +++ b/src/oauth2plugin.cpp
 @@ -336,9 +336,8 @@ void OAuth2Plugin::process(const SignOn::SessionData &inData,
@@ -27,6 +27,3 @@ index 57df6d8..be39263 100644
              TRACE() << "Invalid provided tokens data - continuing normal process flow";
          } else {
              TRACE() << "Storing provided tokens";
--- 
-2.37.2
-

--- a/rpm/0003-Always-install-to-usr-lib-never-usr-lib64.patch
+++ b/rpm/0003-Always-install-to-usr-lib-never-usr-lib64.patch
@@ -8,7 +8,7 @@ Subject: [PATCH] Always install to /usr/lib never /usr/lib64
  1 file changed, 1 insertion(+), 5 deletions(-)
 
 diff --git a/common-project-config.pri b/common-project-config.pri
-index e149d90..68f82de 100644
+index e149d90158618cddae8694c56ee9df32e32bbd27..68f82de5aca9b79b1ba8b7239a8771143bed429c 100644
 --- a/common-project-config.pri
 +++ b/common-project-config.pri
 @@ -50,11 +50,7 @@ exists( meego-release ) {
@@ -24,6 +24,3 @@ index e149d90..68f82de 100644
  
  # default library directory can be overriden by defining LIBDIR when
  # running qmake
--- 
-2.37.2
-

--- a/rpm/0004-Always-force-client-auth-via-request-body.patch
+++ b/rpm/0004-Always-force-client-auth-via-request-body.patch
@@ -8,7 +8,7 @@ Subject: [PATCH] Always force client auth via request body
  1 file changed, 2 insertions(+), 11 deletions(-)
 
 diff --git a/src/oauth2plugin.cpp b/src/oauth2plugin.cpp
-index be39263..3eb3fef 100644
+index be39263083894ae7e190514f92c4996421eebba2..3eb3fef7a7bf2de0b2943d61300267f44907cc03 100644
 --- a/src/oauth2plugin.cpp
 +++ b/src/oauth2plugin.cpp
 @@ -708,17 +708,8 @@ void OAuth2Plugin::sendOAuth2PostRequest(QUrl &postData,
@@ -31,6 +31,3 @@ index be39263..3eb3fef 100644
      } else {
          postData.addQueryItem(CLIENT_ID, d->m_oauth2Data.ClientId());
      }
--- 
-2.37.2
-

--- a/rpm/0006-Add-ExtraParams-to-plugin-data.patch
+++ b/rpm/0006-Add-ExtraParams-to-plugin-data.patch
@@ -12,18 +12,19 @@ to select account.
 
 Signed-off-by: Tomi Leppänen <tomi.leppanen@jolla.com>
 ---
- src/oauth2data.h     | 4 ++++
+ src/oauth2data.h     | 5 +++++
  src/oauth2plugin.cpp | 8 ++++++++
- 2 files changed, 12 insertions(+)
+ 2 files changed, 13 insertions(+)
 
 diff --git a/src/oauth2data.h b/src/oauth2data.h
-index da154f643552dad6ac425ed26ed3c3afebde23d2..dacd3d499cd19ff9345e1e3161bdd8d08a80a82d 100644
+index da154f643552dad6ac425ed26ed3c3afebde23d2..31184974f2cd25be7df5483415496a13f9df2cf0 100644
 --- a/src/oauth2data.h
 +++ b/src/oauth2data.h
-@@ -124,6 +124,10 @@ namespace OAuth2PluginNS {
+@@ -124,6 +124,11 @@ namespace OAuth2PluginNS {
           * query component of the token endpoint URI
           */
          SIGNON_SESSION_DECLARE_PROPERTY(QString, TokenQuery);
++
 +        /*!
 +         * Any extra (non standard) parameters to send to the endpoint URI
 +         */

--- a/rpm/0007-Add-RFC7636-aka-PKCE-support.patch
+++ b/rpm/0007-Add-RFC7636-aka-PKCE-support.patch
@@ -6,8 +6,8 @@ MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
 
-This implements "pixie". It is enabled by default as there should be
-very little harm if the server does not support it. However, if the
+This implements "pixie". It is enabled if the server if the server
+asks for a response type "code". However, if the
 service is broken and may not receive code_challenge, then there is
 SkipPKCE property that can be set to true.
 
@@ -22,6 +22,7 @@ Linux but might behave differently on other platforms and is not
 portable to non Unix-like OSs.
 
 Signed-off-by: Tomi Leppänen <tomi.leppanen@jolla.com>
+Signed-off-by: Björn Bidar <bjorn.bidar@jolla.com>
 ---
  src/oauth2data.h     | 10 ++++++++++
  src/oauth2plugin.cpp | 44 ++++++++++++++++++++++++++++++++++++++++++++
@@ -49,7 +50,7 @@ index 31184974f2cd25be7df5483415496a13f9df2cf0..7b4623b21a6678f7d32b4d4b1e891519
           * Any extra (non standard) parameters to send to the endpoint URI
           */
 diff --git a/src/oauth2plugin.cpp b/src/oauth2plugin.cpp
-index a5f8e9769939ad1e0fe04840ef9208365167369b..452d03a88e927a26a5860a572efe98ef072486ec 100644
+index 561c222bccbc938f2ee878a5e7bea25c13ea06da..0f0f0793947f276ad629933edba4139dcc66cba7 100644
 --- a/src/oauth2plugin.cpp
 +++ b/src/oauth2plugin.cpp
 @@ -25,6 +25,8 @@
@@ -110,7 +111,7 @@ index a5f8e9769939ad1e0fe04840ef9208365167369b..452d03a88e927a26a5860a572efe98ef
          url.addQueryItem(SCOPE, QUrl::toPercentEncoding(scopes.join(" ")));
      }
 +    // PKCE (RFC7636)
-+    if (!d->m_oauth2Data.SkipPKCE()) {
++    if (!d->m_oauth2Data.SkipPKCE() && responseType.contains("code")) {
 +        QByteArray codeVerifier = getRandomCodeVerifier();
 +        d->m_oauth2Data.setCodeVerifier(codeVerifier);
 +        QByteArray codeChallenge = getCodeChallenge(codeVerifier);
@@ -120,7 +121,7 @@ index a5f8e9769939ad1e0fe04840ef9208365167369b..452d03a88e927a26a5860a572efe98ef
      /* If there are extra parameters provided, apply those to the request.
       * This allows to instruct the website to require login for example. */
      QVariantMap extraParams = d->m_oauth2Data.ExtraParams();
-@@ -499,6 +539,10 @@ void OAuth2Plugin::userActionFinished(const SignOn::UiSessionData &data)
+@@ -501,6 +541,10 @@ void OAuth2Plugin::userActionFinished(const SignOn::UiSessionData &data)
              newUrl.addQueryItem(GRANT_TYPE, AUTHORIZATION_CODE);
              newUrl.addQueryItem(AUTH_CODE, code);
              newUrl.addQueryItem(REDIRECT_URI, redirectUri);


### PR DESCRIPTION
In case a service sends token as a response type imply that PKCE shall
not be used.

Also rebase patches with  format-patch --no-numbered --zero-commit --no-signature --full-inde.